### PR TITLE
Очищение скрытых элементов при сбросе фильтра

### DIFF
--- a/mod_jlcontentfieldsfilter/assets/javascript/jlcontentfilter.js
+++ b/mod_jlcontentfieldsfilter/assets/javascript/jlcontentfilter.js
@@ -40,7 +40,7 @@ var JlContentFieldsFilter = {
         var id = form.attr('id');
         var params = this.params[id];
         form.find(':checked, :selected, select')
-            .not(':button, :submit, :reset, :hidden')
+            .not(':button, :submit, :reset')
             .removeAttr('checked')
             .removeAttr('selected');
         form.find('input[type="text"]').val('');


### PR DESCRIPTION
Если отмеченный чекбокс не виден на странице (например, был скрыт в дропдауне), то он не очищался и фильтр сбрасывался не полностью