### PR TITLE
Allow standard Text fields to be used as Checkboxes, Radio, or List filters

### DIFF
--- a/mod_jlcontentfieldsfilter/src/Helper/JlcontentfieldsfilterHelper.php
+++ b/mod_jlcontentfieldsfilter/src/Helper/JlcontentfieldsfilterHelper.php
@@ -116,6 +116,35 @@ class JlcontentfieldsfilterHelper
                         : JPATH_ROOT . '/modules/mod_jlcontentfieldsfilter/layouts'
                     );
 
+                // --- populate from text inputs ---
+                if (\in_array($layout, ['checkboxes', 'list', 'radio']) && $field->type === 'text') {
+                    $db = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+                    $query = $db->getQuery(true)
+                        ->select('DISTINCT value')
+                        ->from($db->quoteName('#__fields_values'))
+                        ->where($db->quoteName('field_id') . ' = ' . (int) $field->id)
+                        ->where($db->quoteName('value') . ' != ' . $db->quote(''));
+
+                    $distinctValues = $db->setQuery($query)->loadColumn();
+
+                    if (!empty($distinctValues)) {
+                        $dynamicOptions = [];
+                        foreach ($distinctValues as $val) {
+                            $opt = new \stdClass();
+                            $opt->value = $val;
+                            $opt->name  = $val; // not shown in the label
+                            $opt->text  = $val; // text for the select
+                            $dynamicOptions[] = $opt;
+                        }
+                        // insert the options in the field
+                        $field->fieldparams->set('options', $dynamicOptions);
+                        
+                        // “Trick” the form by temporarily changing its type,
+                        // allowing the setHiddenOptions() function to process it correctly
+                        $field->type = $layout; 
+                    }
+                }
+
                 if ($field->params->get('field_hidden', false) || $field->params->get('options_hidden', false)) {
                     $field = $this->setHiddenOptions($field, $category_id, $option);
                 }

--- a/plg_system_jlcontentfieldsfilter/src/Extension/Jlcontentfieldsfilter.php
+++ b/plg_system_jlcontentfieldsfilter/src/Extension/Jlcontentfieldsfilter.php
@@ -231,16 +231,33 @@ class Jlcontentfieldsfilter extends CMSPlugin
                 case 'text':
                     if (!empty($v)) {
                         if (\is_array($v)) {
-                            if (!empty($v['from']) && !empty($v['to'])) {
-                                // Security: Cast BOTH values to int to prevent SQL injection
-                                $where = '(field_id = ' . (int)$k . ' AND CAST(value AS SIGNED) BETWEEN ' . (int)$v['from'] . ' AND ' . (int)$v['to'] . ')';
-                            } elseif (!empty($v['from'])) {
-                                $where = '(field_id = ' . (int)$k . ' AND CAST(value AS SIGNED) >= ' . (int)$v['from'] . ')';
-                            } elseif (!empty($v['to'])) {
-                                $where = '(field_id = ' . (int)$k . ' AND CAST(value AS SIGNED) <= ' . (int)$v['to'] . ')';
+                            // Check if it's an array for the range filter (from/to)
+                            if (isset($v['from']) || isset($v['to'])) {
+                                if (!empty($v['from']) && !empty($v['to'])) {
+                                    $where = '(field_id = ' . (int)$k . ' AND CAST(value AS SIGNED) BETWEEN ' . (int)$v['from'] . ' AND ' . (int)$v['to'] . ')';
+                                } elseif (!empty($v['from'])) {
+                                    $where = '(field_id = ' . (int)$k . ' AND CAST(value AS SIGNED) >= ' . (int)$v['from'] . ')';
+                                } elseif (!empty($v['to'])) {
+                                    $where = '(field_id = ' . (int)$k . ' AND CAST(value AS SIGNED) <= ' . (int)$v['to'] . ')';
+                                }
+                            } 
+                            // If it is a standard array (checkbox/list)
+                            else {
+                                $newVal = [];
+                                foreach ($v as $val) {
+                                    if ($val !== '') {
+                                        $newVal[] = $val;
+                                    }
+                                }
+                                if (\count($newVal)) {
+                                    $quotedValues = array_map(function($val) use ($db) {
+                                        return $db->quote($val);
+                                    }, $newVal);
+                                    $where = '(field_id = ' . (int)$k . ' AND value IN(' . implode(', ', $quotedValues) . '))';
+                                }
                             }
                         } else {
-                            // Security: Escape value before using in LIKE to prevent SQL injection
+                            // Default behavior for single text input
                             $escapedValue = $db->escape($v);
                             $where = '(field_id = ' . (int)$k . ' AND value LIKE ' . $db->quote('%' . $escapedValue . '%') . ')';
                         }


### PR DESCRIPTION
#### Motivation
Currently, the module only supports `checkboxes`, `radio`, and `list` layouts for custom fields that natively possess an options array. However, it is very common to have standard `text` fields containing a limited, repetitive set of values that would be perfectly suited for multiple-choice filtering.

#### What this PR does
This PR introduces the ability to render and filter standard `text` fields as multiple-choice inputs, specifically focusing on the **`com_content`** component. It automatically generates the options based on the actual data present in the database for articles.

#### Detailed Changes:
1. **Module (`src/Helper/JlcontentfieldsfilterHelper.php`)**:
   - Intercepts `text` fields when the selected layout is `checkboxes`, `radio`, or `list`.
   - Queries the `#__fields_values` table to extract `DISTINCT` values for that specific field.
   - Dynamically builds the `options` array so the existing layout files can render them properly.
   - Temporarily mimics the layout type to allow the native `setHiddenOptions()` function to hide empty options based on the `com_content` category context.

2. **System Plugin (`src/Extension/Jlcontentfieldsfilter.php`)**:
   - Updates the SQL query builder inside `onAfterRoute()` for the `case 'text':` block.
   - Detects if the input is a standard array of selected options (coming from the new checkboxes/list) and safely constructs an `IN (...)` clause.
   - Preserves the existing logic for `range` arrays (`from`/`to`) and standard single-string `LIKE` searches.

---

### How to Test / Steps to Reproduce

**1. Setup the Custom Field**
* In the Joomla Backend, go to **Content > Fields**.
* Create a new Custom Field of type `Text` (e.g., named "City" or "Color").
* In the "Filtering Params" tab, set the **View in the filter** to `Text` and **Individual layout** to `checkboxes`

**2. Create Test Content**
* Go to **Content > Articles** and create 3 test articles within the same Category (e.g., "Test Category").
* Assign values to the new Text field:
  * Article 1: "Rome"
  * Article 2: "Milan"
  * Article 3: "Rome"
  * *(Optional)* Article 4: Leave the field empty.

**3. Configure the Module**
* Go to **System > Site Modules** and publish the `MOD_JLCONTENTFIELDSFILTER` module on a visible position.
* Assign the module to the "Test Category".

**4. Test the Frontend Rendering**
* Navigate to the "Test Category" page on the frontend.
* Look at the filter module: it should now display a checkbox list with exactly two options: "Rome" and "Milan" (dynamically extracted via `DISTINCT`).
* Empty values from Article 4 should not be rendered as an empty option.

**5. Test the Filtering Logic**
* Check "Rome" and submit the filter form.
* Verify that the category view updates to show **only** Article 1 and Article 3.
* Reset the filter, check "Milan", submit, and verify that only Article 2 is displayed.